### PR TITLE
Updated to 5.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.2.2" %}
+{% set version = "5.3" %}
 
 package:
     name: qrcode
@@ -6,8 +6,8 @@ package:
 
 source:
     fn: qrcode-{{ version }}.tar.gz
-    url: https://pypi.python.org/packages/source/q/qrcode/qrcode-{{ version }}.tar.gz
-    md5: 19b0c93e80087b31681080536f1bfbbd
+    url: https://pypi.io/packages/source/q/qrcode/qrcode-{{ version }}.tar.gz
+    md5: af41b650a3675d0a0366f842de9786b9
 
 build:
     number: 0


### PR DESCRIPTION
Change log
==========

Version 5.3
===========

* Fix incomplete block table for QR version 15. Thanks Rodrigo Queiro for the
  report and Jacob Welsh for the investigation and fix.

* Avoid unnecessary dependency for non MS platforms, thanks to Noah Vesely.

* Make ``BaseImage.get_image()`` actually work.